### PR TITLE
Fix empty session data on prices page by normalizing operating mode

### DIFF
--- a/remote/server/sessiondb/store.go
+++ b/remote/server/sessiondb/store.go
@@ -192,7 +192,7 @@ func (s *Store) GetSummaries(agentID string, hours int) ([]BatterySummary, error
 		       COALESCE(SUM(energy_wh), 0) as total_energy_wh,
 		       COALESCE(SUM(cost_eur), 0) as total_cost_eur
 		FROM sessions
-		WHERE started_at >= ? AND ended_at IS NOT NULL AND operating_mode = 'manual'`
+		WHERE started_at >= ? AND ended_at IS NOT NULL AND operating_mode IN ('manual', '1')`
 	args := []interface{}{cutoff}
 
 	if agentID != "" {

--- a/remote/server/sessions.go
+++ b/remote/server/sessions.go
@@ -168,7 +168,7 @@ func (st *SessionTracker) startSession(key, agentID, batteryName, sessionType st
 		Type:          sessionType,
 		StartedAt:     now,
 		SocStart:      soc,
-		OperatingMode: operatingMode,
+		OperatingMode: normalizeOperatingMode(operatingMode),
 	}
 	id, err := st.store.InsertSession(rec)
 	if err != nil {
@@ -356,6 +356,19 @@ func (st *SessionTracker) Cleanup(retention time.Duration) {
 	}
 	if deleted > 0 {
 		st.log.Info("session cleanup", slog.Int64("deleted", deleted))
+	}
+}
+
+// normalizeOperatingMode converts the Sonnen API numeric operating mode
+// ("1" = manual, "2" = auto) to a human-readable string.
+func normalizeOperatingMode(raw string) string {
+	switch raw {
+	case "1", "manual":
+		return "manual"
+	case "2", "auto":
+		return "auto"
+	default:
+		return raw
 	}
 }
 


### PR DESCRIPTION
The Sonnen API returns operating mode as numeric strings ("1" for manual,
"2" for auto), but the GetSummaries query filtered by operating_mode = 'manual'.
This mismatch caused all session summaries to return zero energy/cost values.

- Normalize operating mode on session start ("1" → "manual", "2" → "auto")
- Update GetSummaries query to also match legacy "1" values in existing DB rows

https://claude.ai/code/session_01SfBp3ZVFGZ1cYBLxkbdcMS